### PR TITLE
Sleep instead of panic when getting rate limit response

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -89,7 +89,7 @@ impl Client {
             Ok(Some(BlockHash::from_str(hex).with_context(|| {
                 format!("failing converting {hex} to BlockHash")
             })?))
-        } else if response.status() == 404 {
+        } else if response.status() == 404 || response.status() == 429 {
             Ok(None)
         } else {
             panic!("{url} return unexpected status {status} for block_hash");

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -92,7 +92,7 @@ impl Client {
         } else if response.status() == 404 || response.status() == 429 {
             Ok(None)
         } else {
-            panic!("{url} return unexpected status {status} for block_hash");
+            Err(format!("{url} return unexpected status {status} for block_hash").into())
         }
     }
 


### PR DESCRIPTION
This PR fixes the panic in case esplora returns 429 status (rate limit). Instead it falls back to sleep and try again.